### PR TITLE
fix: リバーシを正常に行えない問題を修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -63,6 +63,7 @@ module ReversiMethods
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
     return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -87,6 +87,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    return false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
## 概要
以下の問題をテストが通過するように修正しました。
* 正しい位置に石が置かれない
* 石が置かれていない場所を自分の陣地にできてしまう
* 配置できないことを検知できていない

## レビュー観点
```sh
ruby test/reversi_methods_test.rb
```
でテストがすべて通ることの確認をお願いします。

## 補足
